### PR TITLE
단건 + 다건 상품 상세 조회 기능 추가, 상품 카테고리 리스트 url 변경

### DIFF
--- a/src/main/java/com/ll/domain/product/controller/ApiV1ProductController.java
+++ b/src/main/java/com/ll/domain/product/controller/ApiV1ProductController.java
@@ -34,13 +34,30 @@ public class ApiV1ProductController {
     }
 
     @Transactional(readOnly = true)
-    @GetMapping("/{category}")
+    @GetMapping("/category/{category}")
     @Operation(summary = "카테고리별 메뉴 상품 조회", description = "특정 카테고리에 속하는 메뉴 상품 목록을 조회합니다.\n" +
     "'category'는 대문자로 입력해야 합니다. 현재 카테고리는 'ALL', 'COFFEE', 'TEA', 'JUICE 'DESSERT'가 있습니다." +
-    " url 예시: /api/v1/products/ALL , /api/v1/products/COFFEE 등")
+    " url 예시: /api/v1/products/category/ALL , /api/v1/products/category/COFFEE 등")
     public RsData<List<MenuProductDto>> getMenuProductsByCategory(@PathVariable String category) {
         List<MenuProductDto> menuProducts = productService.getMenuProductsByCategory(category);
-        return new RsData<>("200-1", "메뉴 상품 목록을 조회했습니다.", menuProducts);
+        return new RsData<>("200-1", "%s 메뉴 상품 목록을 조회했습니다.".formatted(category), menuProducts);
+    }
+
+    @Transactional(readOnly = true)
+    @GetMapping("/{id}")
+    @Operation(summary = "단건 상품 상세 조회", description = "특정 상품 상세 데이터를 조회합니다.\n" +
+            " url 예시: /api/v1/products/1 , /api/v1/products/2 등")
+    public RsData<Product> getProduct(@PathVariable int id) {
+        Product product = productService.getProduct(id);
+        return new RsData<>("200-1", "%d번 상품 목록을 조회했습니다.".formatted(id), product);
+    }
+
+    @Transactional(readOnly = true)
+    @GetMapping
+    @Operation(summary = "다건 상품 상세 조회", description = "모든 상품 상세 데이터를 조회합니다.")
+    public RsData<List<Product>> getProducts() {
+        List<Product> products = productService.getProducts();
+        return new RsData<>("200-1", "상세 상품 목록을 조회했습니다.", products);
     }
 }
 

--- a/src/main/java/com/ll/domain/product/service/ProductService.java
+++ b/src/main/java/com/ll/domain/product/service/ProductService.java
@@ -86,5 +86,14 @@ public class ProductService {
                 })
                 .toList();
     }
+
+    public Product getProduct(int id) {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다. ID: " + id));
+    }
+
+    public List<Product> getProducts() {
+        return productRepository.findAll();
+    }
 }
 


### PR DESCRIPTION
1. 단건 상품 상세 조회 기능을 추가햇습니다
2. 다건 상품 상세 조회 기능을 추가햇습니다
3. 상품 카테고리 리스트 url 변경 
http://localhost:8080/api/v1/products/DESSERT  ->  http://localhost:8080/api/v1/products/category/DESSERT